### PR TITLE
:bug:cicd(Release): Fix gh actions release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           name: build-artifact
       - name: Get the version
         id: get_version
-        run: echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+        run: echo "VERSION=${echo ${GITHUB_REF/refs\/tags\/v/}| tr / -}" >> $GITHUB_ENV
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest


### PR DESCRIPTION
Fix gh actions release yaml, due to :set-env isn't valid anymore