### PR TITLE
Handle zeroed out time when seconds are :00

### DIFF
--- a/src/main/java/oryanmoshe/kafka/connect/util/TimestampConverter.java
+++ b/src/main/java/oryanmoshe/kafka/connect/util/TimestampConverter.java
@@ -30,7 +30,7 @@ public class TimestampConverter implements CustomConverter<SchemaBuilder, Relati
     public static final List<String> SUPPORTED_DATA_TYPES = List.of("date", "time", "datetime", "timestamp",
             "datetime2");
 
-    private static final String DATETIME_REGEX = "(?<datetime>(?<date>(?:(?<year>\\d{4})-(?<month>\\d{1,2})-(?<day>\\d{1,2}))|(?:(?<day2>\\d{1,2})\\/(?<month2>\\d{1,2})\\/(?<year2>\\d{4}))|(?:(?<day3>\\d{1,2})-(?<month3>\\w{3})-(?<year3>\\d{4})))?(?:\\s?T?(?<time>(?<hour>\\d{1,2}):(?<minute>\\d{1,2}):(?<second>\\d{1,2})\\.?(?<milli>\\d{0,7})?)?))";
+    private static final String DATETIME_REGEX = "(?<datetime>(?<date>(?:(?<year>\\d{4})-(?<month>\\d{1,2})-(?<day>\\d{1,2}))|(?:(?<day2>\\d{1,2})\\/(?<month2>\\d{1,2})\\/(?<year2>\\d{4}))|(?:(?<day3>\\d{1,2})-(?<month3>\\w{3})-(?<year3>\\d{4})))?(?:\\s?T?(?<time>(?:(?<hour>\\d{1,2}):(?<minute>\\d{1,2}):(?<second>\\d{1,2}))\\.?(?<milli>\\d{0,7})|(?:(?<hour2>\\d{1,2}):(?<minute2>\\d{1,2}))?)?))";
     private static final Pattern regexPattern = Pattern.compile(DATETIME_REGEX);
 
     public String strDatetimeFormat, strDateFormat, strTimeFormat;
@@ -141,8 +141,10 @@ public class TimestampConverter implements CustomConverter<SchemaBuilder, Relati
                     : (matches.group("month2") != null ? matches.group("month2") : matches.group("month3")));
             String day = (matches.group("day") != null ? matches.group("day")
                     : (matches.group("day2") != null ? matches.group("day2") : matches.group("day3")));
-            String hour = matches.group("hour") != null ? matches.group("hour") : "00";
-            String minute = matches.group("minute") != null ? matches.group("minute") : "00";
+            String hour = (matches.group("hour") != null ? matches.group("hour")
+                    : (matches.group("hour2") != null ? matches.group("hour2") : "00"));
+            String minute = (matches.group("minute") != null ? matches.group("minute")
+                    : (matches.group("minute2") != null ? matches.group("minute2") : "00"));
             String second = matches.group("second") != null ? matches.group("second") : "00";
             String milli = matches.group("milli") != null ? matches.group("milli") : "000";
 

--- a/src/test/java/oryanmoshe/kafka/connect/util/TimestampConverterTests.java
+++ b/src/test/java/oryanmoshe/kafka/connect/util/TimestampConverterTests.java
@@ -78,7 +78,9 @@ public class TimestampConverterTests {
             "datetime,, 19/04/2019 15:13:20.345123, 2019-04-19T15:13:20.345Z",
             "datetime,, 2019-4-19 15:13:20.345123, 2019-04-19T15:13:20.345Z",
             "datetime2,, 2019-4-19 15:13:20.345123, 2019-04-19T15:13:20.345Z",
-            "datetime,, 2019-4-19 3:1:0.345123, 2019-04-19T03:01:00.345Z", "datetime,YYYY-MM-dd,,", "timestamp,,,", "date,,,"})
+            "datetime,, 2019-4-19 3:1:0.345123, 2019-04-19T03:01:00.345Z",
+            "datetime,, 2019-4-19 15:13, 2019-04-19T15:13:00.000Z",
+            "datetime,YYYY-MM-dd,,", "timestamp,,,", "date,,,"})
     void converterTest(final String columnType, final String format, final String input, final String expectedResult) {
         final TimestampConverter tsConverter = new TimestampConverter();
 


### PR DESCRIPTION
It looks like the datetime type for MySQL does not return the correct value when the seconds part of the datetime is `:00`.   For example, the datetime 2023-04-15T12:34:00 in MySQL will end up as  `2023-04-15T00:00:00` after being processed by this converter.

I have narrowed this behavior down to the fact that a Java `LocalDateTime` object is passed to the converter here for datetime:
https://github.com/debezium/debezium/blob/main/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RowDeserializers.java#L406

The issue is that when the seconds parameter is `:00` the string that is returned omits the seconds piece.

So if you run something like:
```
import java.time.LocalDateTime;

public class Program
{
    public static void main(String[] args) {
	System.out.println(LocalDateTime.of(2023, 4, 15, 12, 34, 5, 0).toString());
        System.out.println(LocalDateTime.of(2023, 4, 15, 12, 34, 0, 0).toString());
	}
}
```

You get:
```
2023-04-15T12:34:05
2023-04-15T12:34
```

The second example comes back without a seconds portion of the datetime string and this doesn't match the `time` portion of the existing regex for this converter.  This results in the entire time portion being zeroed out to -> `2023-04-15T00:00:00`.

The result is that roughly 1 out of 60 timestamps will be wrong (assuming a random distribution of events).

This PR updates the regex to match the `time` group with just hour and minute portions. 

